### PR TITLE
Add a better makefile with dependency tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+CC        = g++
+OBJ       = build
+SRCS     += $(wildcard src/*.cpp)
+DEPDIR   := $(OBJ)/deps
+DEPFILES := $(patsubst src/%.cpp,$(DEPDIR)/%.d,$(SRCS))
+OBJS      = $(patsubst src/%.cpp,$(OBJ)/%.o,$(SRCS))
+DEPFLAGS  = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
+EXE       = nothing
+CFLAGS    = -g -w -std=c++20
+LDLIBS    = -lm -lstdc++
+
+
+all: $(EXE)
+
+$(DEPFILES):
+	@mkdir -p "$(@D)"
+
+$(EXE): $(OBJS) | $(BIN)
+	@echo "($(MODE)) Building final executable $@"
+	@$(CC) $(CFLAGS) $^ -o $@ $(LDLIBS)
+
+$(OBJ)/%.o : src/%.cpp $(DEPDIR)/%.d | $(DEPDIR)
+	@echo "($(MODE)) Compiling $@"
+	@mkdir -p "$(@D)"
+	@$(CC) $(DEPFLAGS) $(CFLAGS) -c $< -o $@ 
+
+$(OBJ):
+	@mkdir -p $@
+
+$(DEPDIR): 
+	@mkdir -p $@
+
+clean:
+	rm -rf build $(EXE)
+
+include $(wildcard $(DEPFILES))

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,0 @@
-CC = g++
-CFLAGS = -w -g  -lstdc++ -lm
-SRCS      = $(wildcard *.cpp)
-nothing: main.o lexer.o parser.o typecheck.o utils.o intermediate.o
-	g++ $(CFLAGS) $(SRCS) -o nothing
-
-.PHONY: clean
-clean:
-	rm *.out *.output *.o *.s nothing 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -86,7 +86,7 @@ struct AST_NODE *parse_block(struct PARSER_STATUS *status, struct AST_NODE *pare
     };
 
     printf("ytttt    %s\n", status->current->literal_value.c_str());
-    consume_assert(status, T_RBRACE, "Expected '}' but received '%s'", status->current->literal_value);
+    consume_assert(status, T_RBRACE, "Expected '}' but received '%s'", status->current->literal_value.c_str());
     return node;
 }
 // @TODO : Add Floats
@@ -111,7 +111,7 @@ struct AST_NODE *parse_type(struct PARSER_STATUS *status, struct AST_NODE *paren
         while(status->current->type == T_LBRACKET) {
 
             consume(status);
-            consume_assert(status, T_RBRACKET, "Expected ']' but received '%s'", status->current->literal_value);
+            consume_assert(status, T_RBRACKET, "Expected ']' but received '%s'", status->current->literal_value.c_str());
 
             printf("Parsing\t::parse_factor\t::\tFound array type\n");
 


### PR DESCRIPTION
This makefile now only builds the .cpp files that have been modified
since the last compilation as opposed to re-building everything.

It also uses dependency-tracking to ensure that files are always
re-built when any of their dependencies change.

Run with `make -j` to compile the different units in parallel